### PR TITLE
Expansion of supported archive types

### DIFF
--- a/QuickLook.Plugin/QuickLook.Plugin.ArchiveViewer/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.ArchiveViewer/Plugin.cs
@@ -26,7 +26,7 @@ namespace QuickLook.Plugin.ArchiveViewer
     public class Plugin : IViewer
     {
         private static readonly string[] Extensions =
-            {".rar", ".zip", ".tar", ".tgz", ".gz", ".bz2", ".lz", ".xz", ".7z"};
+            {".rar", ".zip", ".tar", ".tgz", ".gz", ".bz2", ".lz", ".xz", ".7z", ".jar", ".crx"};
 
         private ArchiveInfoPanel _panel;
 


### PR DESCRIPTION
resolve #772, while adding another file extension type.

Add `.jar` and `.crx` support in plugin `ArchiveViewer`, treating them just like `.zip` files.

*(This would bring convenience to Java Programmers and Chrome extension developers.)*